### PR TITLE
Fix the regexp for arc lint to correctly only match a single line.

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -3,7 +3,7 @@
     "khan-linter": {
       "type": "script-and-regex",
       "script-and-regex.script": "~\/khan\/devtools\/khan-linter\/runlint.py --always-exit-0 --blacklist=yes --propose-arc-fixes",
-      "script-and-regex.regex": "\/^((?P<file>[^:]*):(?P<line>\\d+):((?P<char>\\d+):)? (?P<name>((?P<error>E)|(?P<warning>W))\\S+) (?P<message>[^\\x00]*)(\\x00(?P<original>[^\\x00]*)\\x00(?P<replacement>[^\\x00]*)\\x00)?)|(?P<ignore>SKIPPING.*)$\/m"
+      "script-and-regex.regex": "\/^((?P<file>[^:]*):(?P<line>\\d+):((?P<char>\\d+):)? (?P<name>((?P<error>E)|(?P<warning>W))\\S+) (?P<message>[^\\x00\n]*)(\\x00(?P<original>[^\\x00]*)\\x00(?P<replacement>[^\\x00]*)\\x00)?)|(?P<ignore>SKIPPING.*)$\/m"
     }
   }
 }


### PR DESCRIPTION
Auditors: mroth

Test Plan:
cf. https://phabricator.khanacademy.org/rKLc9b1ea71